### PR TITLE
Right click uses word under cursor or selection if:

### DIFF
--- a/core/contentcmd/cmd.go
+++ b/core/contentcmd/cmd.go
@@ -7,12 +7,19 @@ import (
 	"unicode"
 
 	"github.com/jmigpin/editor/core/cmdutil"
+	"github.com/jmigpin/editor/ui/tautil"
 )
 
 func Cmd(erow cmdutil.ERower) {
+	var s string
 	ta := erow.Row().TextArea
 
-	s := expandLeftRight(ta.Str(), ta.CursorIndex())
+	if ta.SelectionOn() {
+		a, b := tautil.SelectionStringIndexes(ta)
+		s = ta.Str()[a:b]
+	} else {
+		s = expandLeftRight(ta.Str(), ta.CursorIndex())
+	}
 
 	if ok := file(erow, s); ok {
 		return

--- a/ui/textarea.go
+++ b/ui/textarea.go
@@ -489,7 +489,9 @@ func (ta *TextArea) onButtonRelease(ev0 interface{}) {
 		tautil.MoveCursorToPoint(ta, ev.Point, false)
 		tautil.PastePrimary(ta)
 	case ev.Button.Mods.IsButton(3):
-		tautil.MoveCursorToPoint(ta, ev.Point, false)
+		if !ta.PointIndexInsideSelection(ev.Point) {
+			tautil.MoveCursorToPoint(ta, ev.Point, false)
+		}
 		ev2 := &TextAreaCmdEvent{ta}
 		ta.EvReg.RunCallbacks(TextAreaCmdEventId, ev2)
 	}


### PR DESCRIPTION
- selection is available
- click occurs in the current selection