### PR TITLE
Add golang github workflow to the contributing notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,3 +3,14 @@
 Contributions to the master branch are welcome.
 
 The stable branch is an attempt of having something that is not totally broken.
+
+## Github workflow
+
+Golang's import paths makes the usual github workflow a bit different:
+
+1. get the upstream repo via `go get -u github.com/jmigpin/editor`
+2. fork upstream to `git@github.com:FOO/editor.git`
+3. add your fork as a new remote: `cd $GOPATH/src/github.com/jmigpin/editor && git remote add FOO git@github.com:FOO/editor.git`
+4. create a local branch for your feature: `git co -b your-feature-branch`
+5. commit your changes and push them to your remote branch: `git push FOO your-feature-branch`
+6. make a pull request from your fork


### PR DESCRIPTION
... since golang reliance on repo url for import path makes the official
documentation a bit awkward.