### PR TITLE
Use simple markdown lists and blockquote for README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,18 @@ Source code editor in pure Go.
 ![screenshot](./screenshot2.png)
 Screenshot taken using DejaVuSans.ttf font.
 
-This is a know-what-you're-doing source code editor<br>
-As the editor is being developed, the rules of how the UI interacts will become more well defined.<br>
+- This is a know-what-you're-doing source code editor
+- As the editor is being developed, the rules of how the UI interacts will become more well defined.
 
 ### Features
-Auto indentation of wrapped lines.<br>
-No code coloring.<br>
-Many TextArea utilities: undo/redo, replace, comment, ...<br>
-Start external processes from the toolbar with a click, capturing the output to a row. <br>
-Drag and drop files/directories to the editor.<br>
-Detects if files opened are changed outside of the editor.<br>
-Calls goimports if available when saving a .go file.<br>
+
+- Auto indentation of wrapped lines.
+- No code coloring.
+- Many TextArea utilities: undo/redo, replace, comment, ...
+- Start external processes from the toolbar with a click, capturing the output to a row. 
+- Drag and drop files/directories to the editor.
+- Detects if files opened are changed outside of the editor.
+- Calls goimports if available when saving a .go file.
 
 ### Installation and usage
 
@@ -52,101 +53,111 @@ Usage of ./editor:
 ### key/button shortcuts
 
 #### Column key/button shortcuts
-(top right square):<br>
-<kbd>button2</kbd>: close column<br>
+
+(top right square):
+
+- `button2`: close column
 
 #### Row key/button shortcuts
-<kbd>ctrl</kbd>+<kbd>s</kbd>: save file<br>
-<kbd>ctrl</kbd>+<kbd>f</kbd>: warp pointer to "Find" cmd in row toolbar<br>
-Any button press: make row active to layout toolbar commands<br>
-<br>
-(top right square):<br>
-<kbd>button1</kbd> drag: move row to point<br>
-<kbd>button2</kbd>: close row<br>
-<kbd>button3</kbd> drag: resize column<br>
-<kbd>ctrl</kbd>+<kbd>button1</kbd> drag: move row column to point<br>
+
+- `ctrl`+`s`: save file
+- `ctrl`+`f`: warp pointer to "Find" cmd in row toolbar
+- Any button press: make row active to layout toolbar commands
+
+
+(top right square):
+
+- `button1` drag: move row to point
+- `button2`: close row
+- `button3` drag: resize column
+- `ctrl`+`button1` drag: move row column to point
 
 #### Textarea key/button shortcuts
-<kbd>up</kbd>: move cursor up<br>
-<kbd>down</kbd>: move cursor down<br>
-<kbd>left</kbd>: move cursor left<br>
-<kbd>right</kbd>: move cursor right<br>
-<kbd>shift</kbd>+<kbd>up</kbd>: move cursor up adding to selection<br>
-<kbd>shift</kbd>+<kbd>down</kbd>: move cursor down adding to selection<br>
-<kbd>shift</kbd>+<kbd>left</kbd>: move cursor left adding to selection<br>
-<kbd>shift</kbd>+<kbd>right</kbd>: move cursor right adding to selection<br>
-<kbd>delete</kbd>: delete current rune<br>
-<kbd>backspace</kbd>: delete previous rune<br>
-<kbd>end</kbd>: end of line<br>
-<kbd>home</kbd>: start of line<br>
-<kbd>shift</kbd>+<kbd>end</kbd>: end of string<br>
-<kbd>shift</kbd>+<kbd>home</kbd>: start of string<br>
-<kbd>ctrl</kbd>+<kbd>a</kbd>: select all<br>
-<kbd>ctrl</kbd>+<kbd>c</kbd>: copy to clipboard<br>
-<kbd>ctrl</kbd>+<kbd>k</kbd>: remove lines<br>
-<kbd>ctrl</kbd>+<kbd>v</kbd>: paste from clipboard<br>
-<kbd>ctrl</kbd>+<kbd>x</kbd>: cut<br>
-<kbd>ctrl</kbd>+<kbd>mod1</kbd>+<kbd>down</kbd>: move line down<br>
-<kbd>ctrl</kbd>+<kbd>mod1</kbd>+<kbd>shift</kbd>+<kbd>down</kbd>: duplicate lines<br>
-<kbd>tab</kbd> (if selection is on): insert tab at beginning of lines<br>
-<kbd>shift</kbd>+<kbd>tab</kbd>: remove tab from beginning of line<br>
-<kbd>ctrl</kbd>+<kbd>z</kbd>: undo<br>
-<kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>z</kbd>: redo<br>
-<kbd>ctrl</kbd>+<kbd>d</kbd>: comment lines<br>
-<kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>d</kbd>: uncomment lines<br>
-<br>
-<kbd>button1</kbd>: move cursor to point<br>
-<kbd>button2</kbd>: paste from primary<br>
-<kbd>button3</kbd>: move cursor to point + text area cmd<br>
-<kbd>button4</kbd>: scroll up<br>
-<kbd>button5</kbd>: scroll down<br>
-<kbd>shift</kbd>+<kbd>button1</kbd>: move cursor to point adding to selection<br>
 
-Note: selecting text with <kbd>button1</kbd> works as copy and makes it available for paste (primary selection).
+- `up`: move cursor up
+- `down`: move cursor down
+- `left`: move cursor left
+- `right`: move cursor right
+- `shift`+`up`: move cursor up adding to selection
+- `shift`+`down`: move cursor down adding to selection
+- `shift`+`left`: move cursor left adding to selection
+- `shift`+`right`: move cursor right adding to selection
+- `delete`: delete current rune
+- `backspace`: delete previous rune
+- `end`: end of line
+- `home`: start of line
+- `shift`+`end`: end of string
+- `shift`+`home`: start of string
+- `ctrl`+`a`: select all
+- `ctrl`+`c`: copy to clipboard
+- `ctrl`+`k`: remove lines
+- `ctrl`+`v`: paste from clipboard
+- `ctrl`+`x`: cut
+- `ctrl`+`mod1`+`down`: move line down
+- `ctrl`+`mod1`+`shift`+`down`: duplicate lines
+- `tab` (if selection is on): insert tab at beginning of lines
+- `shift`+`tab`: remove tab from beginning of line
+- `ctrl`+`z`: undo
+- `ctrl`+`shift`+`z`: redo
+- `ctrl`+`d`: comment lines
+- `ctrl`+`shift`+`d`: uncomment lines
+
+- `button1`: move cursor to point
+- `button2`: paste from primary
+- `button3`: move cursor to point + text area cmd
+- `button4`: scroll up
+- `button5`: scroll down
+- `shift`+`button1`: move cursor to point adding to selection
+
+Note: selecting text with `button1` works as copy and makes it available for paste (primary selection).
 
 ### Commands
 
 #### Layout toolbar commands (top toolbar)
-ListSessions: lists saved sessions<br>
-SaveSession \<name\>: save session to ~/.editor_sessions.json<br>
-DeleteSession \<name\>: deletes the session from the sessions file<br>
-NewColumn: opens new column<br>
-NewRow: opens new row<br>
-ReopenRow: reopen a previously closed row<br>
-SaveAllFiles: saves all files<br>
-ReloadAll: reloads all filepaths<br>
-ReloadAllFiles: reloads all filepaths that are files<br>
-XdgOpenDir: calls xdg-open to open the active row directory with the preferred external application (ex: a filemanager)<br>
-RowDirectory: open row with the active row directory: useful when editing a file and want to access the file directory contents<br>
-DuplicateRow: make active row share the edit history with a new row that updates when changes are made.<br>
-Exit: exits the program<br>
+
+- `ListSessions`: lists saved sessions
+- `SaveSession <name>`: save session to ~/.editor_sessions.json
+- `DeleteSession <name>`: deletes the session from the sessions file
+- `NewColumn`: opens new column
+- `NewRow`: opens new row
+- `ReopenRow`: reopen a previously closed row
+- `SaveAllFiles`: saves all files
+- `ReloadAll`: reloads all filepaths
+- `ReloadAllFiles`: reloads all filepaths that are files
+- `XdgOpenDir`: calls xdg-open to open the active row directory with the preferred external application (ex: a filemanager)
+- `RowDirectory`: open row with the active row directory: useful when editing a file and want to access the file directory contents
+- `DuplicateRow`: make active row share the edit history with a new row that updates when changes are made.
+- `Exit`: exits the program
 
 Note: Some row commands work from the layout toolbar because they act on the current active row (ex: Find, Replace).
 
 #### Row toolbar commands
-Save: save file<br>
-Reload: reload content<br>
-Close: close row<br>
-CloseColumn: closes row column<br>
-Find: find string (ignores case)<br>
-GotoLine \<num\>: goes to line number<br>
-Replace \<old\> \<new\>: replaces old string with new, respects selections<br>
-Stop: stops current processing (external cmd) running in the row<br>
-ListDir: lists directory<br>
-ListDirSub: lists directory and sub directories<br>
-ListDirHidden: lists directory including hidden<br>
+
+- `Save`: save file
+- `Reload`: reload content
+- `Close`: close row
+- `CloseColumn`: closes row column
+- `Find`: find string (ignores case)
+- `GotoLine <num>`: goes to line number
+- `Replace <old> <new>`: replaces old string with new, respects selections
+- `Stop`: stops current processing (external cmd) running in the row
+- `ListDir`: lists directory
+- `ListDirSub`: lists directory and sub directories
+- `ListDirHidden`: lists directory including hidden
 
 #### Textarea commands
-OpenSession \<name\>: opens previously saved session<br>
-\<url\>: opens url in x-www-browser<br>
-\<filepath\>: opens filepath<br>
-\<filename:number\>: opens filename at line (usual format from compilers)<br>
-\<quoted string\>: opens filepath if existent on goroot/gopath<br>
+
+- `OpenSession <name>`: opens previously saved session
+- `<url>`: opens url in x-www-browser
+- `<filepath>`: opens filepath
+- `<filename:number>`: opens filename at line (usual format from compilers)
+- `<quoted string>`: opens filepath if existent on goroot/gopath
 
 ### Notes
-Uses X shared memory extension (MIT-SHM). <br>
-MacOS might need to have XQuartz installed.<br>
-Notable projects that inspired many features:<br>
-Oberon OS: https://www.youtube.com/watch?v=UTIJaKO0iqU <br>
-Acme editor: https://www.youtube.com/watch?v=dP1xVpMPn8M <br>
+
+- Uses X shared memory extension (MIT-SHM). 
+- MacOS might need to have XQuartz installed.
+- Notable projects that inspired many features:
+- Oberon OS: https://www.youtube.com/watch?v=UTIJaKO0iqU 
+- Acme editor: https://www.youtube.com/watch?v=dP1xVpMPn8M 
 


### PR DESCRIPTION
The current syntax seems a bit weird. This PR removes inline HTML and escapes with the standard markdown lists and blockquotes. 