### PR TITLE
Adding mouse drag and wheel events to RowSquare

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,9 +486,12 @@ Plugins located at: `./plugins`.
 *Row key/button shortcuts*
 
 - `ctrl`+`s`: save file
+- `ctrl`+`w`: close row
 - `ctrl`+`f`: warp pointer to "Find" cmd in row toolbar
+- `ctrl`+`h`: warp pointer to "Replace" cmd in row toolbar
+- `ctrl`+`n`: warp pointer to "NewFile" cmd in row toolbar
 - `buttonLeft` on square-button: close row
-- on top border:
+- on top border (or row square):
 	- `buttonLeft`: drag to move/resize row
 	- `buttonMiddle`: close row
 	- `buttonWheelUp`: adjust row vertical position, pushing other rows up

--- a/core/erow.go
+++ b/core/erow.go
@@ -273,6 +273,8 @@ func (erow *ERow) initHandlers() {
 				FindShortcut(erow)
 			case mods.Is(event.ModCtrl) && evt.KeySym == event.KSymH:
 				ReplaceShortcut(erow)
+			case mods.Is(event.ModCtrl) && evt.KeySym == event.KSymN:
+				NewFileShortcut(erow)
 			}
 		case *event.MouseDown:
 			erow.Info.UpdateActiveRowState(erow)

--- a/core/erow.go
+++ b/core/erow.go
@@ -271,6 +271,8 @@ func (erow *ERow) initHandlers() {
 				}
 			case mods.Is(event.ModCtrl) && evt.KeySym == event.KSymF:
 				FindShortcut(erow)
+			case mods.Is(event.ModCtrl) && evt.KeySym == event.KSymH:
+				ReplaceShortcut(erow)
 			}
 		case *event.MouseDown:
 			erow.Info.UpdateActiveRowState(erow)

--- a/core/erow.go
+++ b/core/erow.go
@@ -275,6 +275,8 @@ func (erow *ERow) initHandlers() {
 				ReplaceShortcut(erow)
 			case mods.Is(event.ModCtrl) && evt.KeySym == event.KSymN:
 				NewFileShortcut(erow)
+			case mods.Is(event.ModCtrl) && evt.KeySym == event.KSymW:
+				row.Close()
 			}
 		case *event.MouseDown:
 			erow.Info.UpdateActiveRowState(erow)

--- a/core/findshortcut.go
+++ b/core/findshortcut.go
@@ -109,3 +109,17 @@ func FindShortcut(erow *ERow) {
 	p.Y += tb.LineHeight() * 3 / 4 // center of rune
 	erow.Ed.UI.WarpPointer(p)
 }
+
+// Search/add the toolbar find command and warps the pointer to it.
+func ReplaceShortcut(erow *ERow) {
+	if err := ToolbarUpdate(erow, "Replace"); err != nil {
+		erow.Ed.Error(err)
+		return
+	}
+
+	// warp pointer to toolbar close to "Find " text cmd to be able to click for run
+	tb := erow.Row.Toolbar
+	p := tb.GetPoint(tb.CursorIndex())
+	p.Y += tb.LineHeight() * 3 / 4 // center of rune
+	erow.Ed.UI.WarpPointer(p)
+}

--- a/core/findshortcut.go
+++ b/core/findshortcut.go
@@ -110,14 +110,28 @@ func FindShortcut(erow *ERow) {
 	erow.Ed.UI.WarpPointer(p)
 }
 
-// Search/add the toolbar find command and warps the pointer to it.
+// Search/add the toolbar Replace command and warps the pointer to it.
 func ReplaceShortcut(erow *ERow) {
 	if err := ToolbarUpdate(erow, "Replace"); err != nil {
 		erow.Ed.Error(err)
 		return
 	}
 
-	// warp pointer to toolbar close to "Find " text cmd to be able to click for run
+	// warp pointer to toolbar close to added text
+	tb := erow.Row.Toolbar
+	p := tb.GetPoint(tb.CursorIndex())
+	p.Y += tb.LineHeight() * 3 / 4 // center of rune
+	erow.Ed.UI.WarpPointer(p)
+}
+
+// Search/add the toolbar NewFile command and warps the pointer to it.
+func NewFileShortcut(erow *ERow) {
+	if err := ToolbarUpdate(erow, "NewFile"); err != nil {
+		erow.Ed.Error(err)
+		return
+	}
+
+	// warp pointer to toolbar close to added text
 	tb := erow.Row.Toolbar
 	p := tb.GetPoint(tb.CursorIndex())
 	p.Y += tb.LineHeight() * 3 / 4 // center of rune

--- a/core/findshortcut.go
+++ b/core/findshortcut.go
@@ -7,46 +7,39 @@ import (
 	"github.com/jmigpin/editor/core/toolbarparser"
 )
 
-// Search/add the toolbar find command and warps the pointer to it.
-func FindShortcut(erow *ERow) {
-	if err := findShortcut2(erow); err != nil {
-		erow.Ed.Error(err)
-		return
-	}
-
-	// warp pointer to toolbar close to "Find " text cmd to be able to click for run
-	tb := erow.Row.Toolbar
-	p := tb.GetPoint(tb.CursorIndex())
-	p.Y += tb.LineHeight() * 3 / 4 // center of rune
-	erow.Ed.UI.WarpPointer(p)
-}
-
-func findShortcut2(erow *ERow) error {
-	// check if there is a selection in the textarea
-	searchB := []byte{}
+func CaptureSelection(erow *ERow) []byte {
+	text := []byte{}
 	ta := erow.Row.TextArea
-	if b, ok := ta.EditCtx().Selection(); ok {
+
+	// check if there is a selection in the textarea
+	if selection_text, ok := ta.EditCtx().Selection(); ok {
 		// don't use if selection has more then one line
-		if !bytes.ContainsRune(b, '\n') {
-			searchB = b
+		if !bytes.ContainsRune(selection_text, '\n') {
+			text = selection_text
 			// quote if it has spaces
-			if bytes.ContainsRune(searchB, ' ') {
-				searchB = []byte(strconv.Quote(string(searchB)))
+			if bytes.ContainsRune(text, ' ') {
+				text = []byte(strconv.Quote(string(text)))
 			}
 		}
 	}
+	return text
+}
 
+func ToolbarMatch(erow *ERow, s string) (*toolbarparser.Part, bool) {
 	// find cmd in toolbar string
 	found := false
 	var part *toolbarparser.Part
 	for _, p := range erow.TbData.Parts {
-		if len(p.Args) > 0 && p.Args[0].Str() == "Find" {
+		if len(p.Args) > 0 && p.Args[0].Str() == s {
 			found = true
 			part = p
 			// don't break, find the last one
 		}
 	}
+	return part, found
+}
 
+func ToolbarInsertion(erow *ERow, part *toolbarparser.Part, capture []byte, found bool, command string) error {
 	tb := erow.Row.Toolbar
 	c := tb.Cursor()
 
@@ -70,28 +63,49 @@ func findShortcut2(erow *ERow) error {
 		}
 
 		// replace current find cmd string with search str
-		if len(searchB) != 0 {
-			if err := tb.RW().OverwriteAt(a, b-a, searchB); err != nil {
+		if len(capture) != 0 {
+			if err := tb.RW().OverwriteAt(a, b-a, capture); err != nil {
 				return err
 			}
-			c.SetSelection(a, a+len(searchB))
+			c.SetSelection(a, a+len(capture))
 		}
 	} else {
 		// insert find cmd
 		tbl := tb.RW().Max()
-		find := " | Find "
+		find := " | " + command + " "
 		if err := tb.RW().OverwriteAt(tbl, 0, []byte(find)); err != nil {
 			return err
 		}
 		a := tbl + len(find)
-		if len(searchB) != 0 {
-			if err := tb.RW().OverwriteAt(a, 0, searchB); err != nil {
+		if len(capture) != 0 {
+			if err := tb.RW().OverwriteAt(a, 0, capture); err != nil {
 				return err
 			}
-			c.SetSelection(a, a+len(searchB))
+			c.SetSelection(a, a+len(capture))
 		} else {
-			c.SetIndexSelectionOff(a + len(searchB))
+			c.SetIndexSelectionOff(a + len(capture))
 		}
 	}
 	return nil
+}
+
+// update toolbar with shortcut
+func ToolbarUpdate(erow *ERow, strToMatch string) error {
+	capture := CaptureSelection(erow)
+	part, found := ToolbarMatch(erow, strToMatch)
+	return ToolbarInsertion(erow, part, capture, found, strToMatch)
+}
+
+// Search/add the toolbar find command and warps the pointer to it.
+func FindShortcut(erow *ERow) {
+	if err := ToolbarUpdate(erow, "Find"); err != nil {
+		erow.Ed.Error(err)
+		return
+	}
+
+	// warp pointer to toolbar close to "Find " text cmd to be able to click for run
+	tb := erow.Row.Toolbar
+	p := tb.GetPoint(tb.CursorIndex())
+	p.Y += tb.LineHeight() * 3 / 4 // center of rune
+	erow.Ed.UI.WarpPointer(p)
 }

--- a/ui/rowsquare.go
+++ b/ui/rowsquare.go
@@ -119,6 +119,10 @@ func (sq *RowSquare) OnInputEvent(ev interface{}, p image.Point) event.Handled {
 	case *event.MouseDragMove:
 		sq.row.sep.OnInputEvent(ev, p)
 
+	// handle scroll events from row separator (allows mouse-wheel ops from rowsquare)
+	case *event.MouseDown:
+		sq.row.sep.OnInputEvent(ev, p)
+
 	case *event.MouseClick:
 		switch t.Button {
 		case event.ButtonLeft, event.ButtonMiddle, event.ButtonRight:

--- a/ui/rowsquare.go
+++ b/ui/rowsquare.go
@@ -114,6 +114,11 @@ func (sq *RowSquare) HasState(s RowState) bool {
 }
 func (sq *RowSquare) OnInputEvent(ev interface{}, p image.Point) event.Handled {
 	switch t := ev.(type) {
+
+	// use drag events from row separator (allows dragging using rowsquare)
+	case *event.MouseDragMove:
+		sq.row.sep.OnInputEvent(ev, p)
+
 	case *event.MouseClick:
 		switch t.Button {
 		case event.ButtonLeft, event.ButtonMiddle, event.ButtonRight:

--- a/ui/rowsquare.go
+++ b/ui/rowsquare.go
@@ -117,7 +117,12 @@ func (sq *RowSquare) OnInputEvent(ev interface{}, p image.Point) event.Handled {
 
 	// use drag events from row separator (allows dragging using rowsquare)
 	case *event.MouseDragMove:
+		sq.Cursor = event.MoveCursor
 		sq.row.sep.OnInputEvent(ev, p)
+
+	// when exiting a drag, make sure the cursor is back to the default
+	case *event.MouseDragEnd:
+		sq.Cursor = event.CloseCursor
 
 	// handle scroll events from row separator (allows mouse-wheel ops from rowsquare)
 	case *event.MouseDown:


### PR DESCRIPTION
Hello--

Just a couple small tweaks I made for myself, but if you're interested in pulling them upstream, feel free.

When moving panels around, I had a little trouble reliably hitting the top border of the row, and I thought it would be intuitive to use the RowSquare region for the same input events. I don't believe this conflicts with any other input events with the RowSquare.

Implementation-wise, it's just forwarding the events to the RowSeparator, so any future changes there should be carried through.