### PR TITLE
lsproto - use notification struct on noreply messages.

### DIFF
--- a/core/lsproto/client.go
+++ b/core/lsproto/client.go
@@ -534,9 +534,11 @@ func jsonGetPath2(v interface{}, args []string) (interface{}, error) {
 			if v, ok := t[a]; ok {
 				return jsonGetPath2(v, args[1:])
 			}
+			return nil, fmt.Errorf("not found: %v", args[0])
 		}
 	case bool, int, float32, float64:
 		return t, nil
 	}
-	return nil, fmt.Errorf("not found: %v", args[0])
+
+	return nil, nil
 }

--- a/core/lsproto/codec.go
+++ b/core/lsproto/codec.go
@@ -52,11 +52,22 @@ func (c *JsonCodec) WriteRequest(req *rpc.Request, data interface{}) error {
 		method = m
 	}
 
-	msg := &RequestMessage{
-		JsonRpc: "2.0",
-		Id:      int(req.Seq),
-		Method:  method,
-		Params:  data,
+	var msg interface{}
+	if  noreply {
+		// don't send an Id on messages that don't need an acknowledgement
+		msg = &NotificationMessage{
+			JsonRpc: "2.0",
+			Method:  method,
+			Params:  data,
+		}
+	} else {
+		// default case includes the Id
+		msg = &RequestMessage{
+			JsonRpc: "2.0",
+			Id:      int(req.Seq),
+			Method:  method,
+			Params:  data,
+		}
 	}
 	//logPrintf("write req -->: %v(%v)", msg.Method, msg.Id)
 

--- a/core/lsproto/protocoltypes.go
+++ b/core/lsproto/protocoltypes.go
@@ -25,6 +25,7 @@ type ResponseMessage struct {
 	Result json.RawMessage `json:"result,omitempty"`
 }
 type NotificationMessage struct {
+	JsonRpc string      `json:"jsonrpc"`
 	Method string      `json:"method,omitempty"`
 	Params interface{} `json:"params,omitempty"`
 }


### PR DESCRIPTION
I noticed an issue with clangd language server failing on some messages and tracked the issue back to the 'Id' parameter being included on some methods that should not have one. 

This change uses the "noreply" tag on messages to choose the appropriate Json struct for the job. `RequestMessage` is used for request-response messages, and `NotificationMessage` (no Id) is used for one-way requests.

For example: `document/didOpen', when passed with an Id causes clangd to respond with "method not found," and subsequently will not provide useful data back to the editor. Similar issues occurred with `initialize` and `document/didClose` methods, and probably others.

Testing with gopls shows no breakage. I'm not very familiar with the LSP spec, but I think the change makes this implementation more correct. Still need to verify  that Python LSP is working as expected.

As a detail worth critique: I co-opted the NotificationMessage struct because, even though it represents a response that should come _back_ from the language server,  it seems to work fine in both cases, once we add the `JsonRpc` field.

(Leaving this as a draft PR until ready to merge so it can be rebased to the most up-to-date master.)