### PR TITLE
lsproto: jump to implementation support

### DIFF
--- a/core/contentcmds/gotoimplementationlsproto.go
+++ b/core/contentcmds/gotoimplementationlsproto.go
@@ -1,0 +1,85 @@
+package contentcmds
+
+import (
+	"context"
+	"io/ioutil"
+	"time"
+
+	"github.com/jmigpin/editor/core"
+	"github.com/jmigpin/editor/core/lsproto"
+	"github.com/jmigpin/editor/util/iout/iorw"
+	"github.com/jmigpin/editor/util/parseutil"
+)
+
+func GoToImplementationLSProto(ctx context.Context, erow *core.ERow, index int) (error, bool) {
+	if erow.Info.IsDir() {
+		return nil, false
+	}
+
+	// timeout for the cmd to run
+	timeout := 8 * time.Second
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ed := erow.Ed
+	ta := erow.Row.TextArea
+	rw := ta.RW()
+
+	// must have a registration that handles the filename
+	_, err := ed.LSProtoMan.LangManager(erow.Info.Name())
+	if err != nil {
+		return nil, false
+	}
+
+	filename, rang, err := ed.LSProtoMan.TextDocumentImplementation(ctx, erow.Info.Name(), rw, index)
+	if err != nil {
+		return err, true
+	}
+
+	// content reader
+	var rd iorw.ReaderAt
+	info, ok := ed.ERowInfo(filename)
+	if ok {
+		// file is in memory already
+		if erow0, ok := info.FirstERow(); ok {
+			rd = erow0.Row.TextArea.RW()
+		}
+	}
+	if rd == nil {
+		// read file
+		b, err := ioutil.ReadFile(filename)
+		if err != nil {
+			return err, true
+		}
+		rd = iorw.NewBytesReadWriterAt(b)
+	}
+
+	// translate range
+	offset, length, err := lsproto.RangeToOffsetLen(rd, rang)
+	if err != nil {
+		return err, true
+	}
+
+	// build filepos
+	filePos := &parseutil.FilePos{
+		Filename: filename,
+		Offset:   offset,
+		Len:      length,
+	}
+
+	erow.Ed.UI.RunOnUIGoRoutine(func() {
+		// place the file under the calling row
+		rowPos := erow.Row.PosBelow() // needs ui goroutine
+
+		conf := &core.OpenFileERowConfig{
+			FilePos:               filePos,
+			RowPos:                rowPos,
+			FlashVisibleOffsets:   true,
+			NewIfNotExistent:      true,
+			NewIfOffsetNotVisible: true,
+		}
+		core.OpenFileERow(erow.Ed, conf) // needs ui goroutine
+	})
+
+	return nil, true
+}

--- a/core/contentcmds/init.go
+++ b/core/contentcmds/init.go
@@ -6,8 +6,9 @@ import (
 
 func init() {
 	// order matters
-
+	core.ContentCmds.Append("gotoimplementation_lsproto", GoToImplementationLSProto)
 	core.ContentCmds.Append("gotodefinition_lsproto", GoToDefinitionLSProto)
+	
 
 	// "gopls query" might work where lsproto might fail (no views in session)
 	core.ContentCmds.Append("gotodefinition", GoToDefinitionGolang)

--- a/core/lsproto/client.go
+++ b/core/lsproto/client.go
@@ -388,6 +388,29 @@ func (cli *Client) TextDocumentDefinition(ctx context.Context, filename string, 
 
 //----------
 
+func (cli *Client) TextDocumentImplementation(ctx context.Context, filename string, pos Position) (*Location, error) {
+	// https://microsoft.github.io/language-server-protocol/specification#textDocument_implementation
+
+	opt := &TextDocumentPositionParams{}
+	opt.Position = pos
+	url, err := parseutil.AbsFilenameToUrl(filename)
+	if err != nil {
+		return nil, err
+	}
+	opt.TextDocument.Uri = DocumentUri(url)
+
+	result := []*Location{}
+	if err := cli.Call(ctx, "textDocument/implementation", &opt, &result); err != nil {
+		return nil, err
+	}
+	if len(result) == 0 {
+		return nil, fmt.Errorf("no results")
+	}
+	return result[0], nil // first result only	
+}
+
+//----------
+
 func (cli *Client) TextDocumentCompletion(ctx context.Context, filename string, pos Position) (*CompletionList, error) {
 	// https://microsoft.github.io/language-server-protocol/specification#textDocument_completion
 

--- a/core/lsproto/manager.go
+++ b/core/lsproto/manager.go
@@ -100,9 +100,15 @@ func (man *Manager) Close() error {
 //----------
 
 func (man *Manager) TextDocumentImplementation(ctx context.Context, filename string, rd iorw.ReaderAt, offset int) (string, *Range, error) {
-	cli, _, err := man.langInstanceClient(ctx, filename)
+	cli, li, err := man.langInstanceClient(ctx, filename)
 	if err != nil {
 		return "", nil, err
+	}
+	
+	// some languages don't need to check for implementations (definitions are enough)
+	languagesToBypass := "python go javascript"
+	if strings.Contains(languagesToBypass, strings.ToLower(li.lang.Reg.Language) ) {
+		return "", nil, nil
 	}
 
 	dir := filepath.Dir(filename)

--- a/core/lsproto/manager.go
+++ b/core/lsproto/manager.go
@@ -99,6 +99,43 @@ func (man *Manager) Close() error {
 
 //----------
 
+func (man *Manager) TextDocumentImplementation(ctx context.Context, filename string, rd iorw.ReaderAt, offset int) (string, *Range, error) {
+	cli, _, err := man.langInstanceClient(ctx, filename)
+	if err != nil {
+		return "", nil, err
+	}
+
+	dir := filepath.Dir(filename)
+	if err := cli.UpdateWorkspaceFolder(ctx, dir); err != nil {
+		return "", nil, err
+	}
+
+	if err := man.didOpenVersion(ctx, cli, filename, rd); err != nil {
+		return "", nil, err
+	}
+	defer man.didClose(ctx, cli, filename)
+
+	pos, err := OffsetToPosition(rd, offset)
+	if err != nil {
+		return "", nil, err
+	}
+
+	loc, err := cli.TextDocumentImplementation(ctx, filename, pos)
+	if err != nil {
+		return "", nil, err
+	}
+
+	// target filename
+	filename2, err := parseutil.UrlToAbsFilename(string(loc.Uri))
+	if err != nil {
+		return "", nil, err
+	}
+
+	return filename2, loc.Range, nil
+}
+
+//----------
+
 func (man *Manager) TextDocumentDefinition(ctx context.Context, filename string, rd iorw.ReaderAt, offset int) (string, *Range, error) {
 	cli, _, err := man.langInstanceClient(ctx, filename)
 	if err != nil {


### PR DESCRIPTION
This allows the lsproto subsystem to do jumps to directly to implementations. This isn't necessary for Go code, but for languages where defs are separated (C/C++), it can be helpful.

As an example, if we have the following files:

```
// foo.h -------- definitions
void foo(void);
```
and 
```
// foo.c ------- implementations
void foo(void) { 
    printf("Foo\n");
}
```
The strategy is to check for an implementation first (foo.c) and if one is not found, go to the definition (foo.h). This is done using the standard Internal Command strategy included in the editor. For cases where there the implementation doesn't exist, there are no failures emitted. Compatibility should be fine, and in theory this should work for any lsproto server.

The code is mainly just a copy-paste of `textDocument/definition` but since there is so much repeated code it would be ideal to rework the code a bit, for maintenance reasons.