### PR TITLE
Hacked together way to update font size in-editor

### DIFF
--- a/core/internalcmds/init.go
+++ b/core/internalcmds/init.go
@@ -69,6 +69,7 @@ func init() {
 
 	cmd("ColorTheme", ColorTheme)
 	cmd("FontTheme", FontTheme)
+	cmd("FontSize", FontSize)
 
 	cmd("CtxutilCallsState", CtxutilCallsState)
 }

--- a/core/internalcmds/misc.go
+++ b/core/internalcmds/misc.go
@@ -2,6 +2,7 @@ package internalcmds
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/jmigpin/editor/core"
 	"github.com/jmigpin/editor/ui"
@@ -179,6 +180,22 @@ func ColorTheme(args *core.InternalCmdArgs) error {
 }
 func FontTheme(args *core.InternalCmdArgs) error {
 	ui.FontThemeCycler.Cycle(args.Ed.UI.Root)
+	args.Ed.UI.Root.MarkNeedsLayoutAndPaint()
+	return nil
+}
+
+func FontSize(args *core.InternalCmdArgs) error {
+	if len(args.Part.Args) != 2 {
+		args.Ed.Errorf("missing font size argument")
+		return nil
+	}
+	fontSize,err := strconv.ParseFloat(args.Part.Args[1].Str(),8)
+	if err != nil {
+		args.Ed.Errorf("cannot parse font size")
+		return nil
+	}
+	ui.TTFontOptions.Size =  fontSize
+	ui.RegularThemeFont(args.Ed.UI.Root)
 	args.Ed.UI.Root.MarkNeedsLayoutAndPaint()
 	return nil
 }

--- a/ui/theme.go
+++ b/ui/theme.go
@@ -232,6 +232,10 @@ var FontThemeCycler cycler = cycler{
 func regularThemeFont(node widget.Node) {
 	loadThemeFont("regular", node)
 }
+func RegularThemeFont(node widget.Node) {
+	regularThemeFont(node)
+}
+
 func mediumThemeFont(node widget.Node) {
 	loadThemeFont("medium", node)
 }


### PR DESCRIPTION
I've been using this for a little while and thought it was useful.

Allows the user to change the font-size while inside the editor by using something like `| FontSize 15 |` in a title bar. 

One caveat: When doing this it doesn't respect the active typeface, so if in a monospaced font is active, when used it will revert to the default variable pitch font, but at the new size. Subsequent changes maintain the size however.