### PR TITLE
Gruvbox-inspired theme

### DIFF
--- a/ui/theme.go
+++ b/ui/theme.go
@@ -234,19 +234,7 @@ func gruvboxThemeColors(node widget.Node) {
 		"contextfloatbox_border": cint(0x282828),
 	}
 	
-	p := widget.Palette{
-		"rs_active":              cint(0x282828),
-		"rs_executing":           cint(0x79740e),                       // dark green
-		"rs_edited":              cint(0x076678),                       // blue
-		"rs_disk_changes":        cint(0xcc241d),                       // red
-		"rs_not_exist":           cint(0xd65d0e),                       // orange
-		"rs_duplicate":           cint(0x83a598),                       // blueish
-		"rs_duplicate_highlight": cint(0xd79921),                       // yellow
-		"rs_annotations":         cint(0xb57614),                       // pumpkin
-		"rs_annotations_edited":  imageutil.Tint(cint(0xd35400), 0.45), // pumpkin (brighter)
-	}
-	
-	pal.Merge(p)
+	pal.Merge(rowSquarePalette())
 	pal.Merge(userPalette())
 	node.Embed().SetThemePalette(pal)
 }

--- a/ui/theme.go
+++ b/ui/theme.go
@@ -272,10 +272,10 @@ func rowSquarePalette() widget.Palette {
 
 var ColorThemeCycler cycler = cycler{
 	entries: []cycleEntry{
-		{"gruvbox", gruvboxThemeColors},
 		{"light", lightThemeColors},
 		{"dark", darkThemeColors},
 		{"acme", acmeThemeColors},
+		{"gruvbox", gruvboxThemeColors},
 	},
 }
 

--- a/ui/theme.go
+++ b/ui/theme.go
@@ -194,15 +194,15 @@ func acmeThemeColors(node widget.Node) {
 
 func gruvboxThemeColors(node widget.Node) {
 	pal := widget.Palette{
-		"text_cursor_fg":            cint(0xffffff),
+		"text_cursor_fg":            cint(0xd79921),
 		"text_fg":                   cint(0xfbf1c7),
 		"text_bg":                   cint(0x282828),
 		"text_selection_fg":         nil,
-		"text_selection_bg":         cint(0x928374),
+		"text_selection_bg":         cint(0x504945),
 		"text_colorize_string_fg":   cint(0xb8bb26),
 		"text_colorize_comments_fg": cint(0xa89984), 
-		"text_highlightword_fg":     nil,
-		"text_highlightword_bg":     cint(0x504945),
+		"text_highlightword_fg":     cint(0x1d2021),
+		"text_highlightword_bg":     cint(0xf9f5d7),
 		"text_wrapline_fg":          cint(0x0),
 		"text_wrapline_bg":          cint(0xd8d8c6),
 

--- a/ui/theme.go
+++ b/ui/theme.go
@@ -233,8 +233,20 @@ func gruvboxThemeColors(node widget.Node) {
 
 		"contextfloatbox_border": cint(0x282828),
 	}
-
-	pal.Merge(rowSquarePalette())
+	
+	p := widget.Palette{
+		"rs_active":              cint(0x282828),
+		"rs_executing":           cint(0x79740e),                       // dark green
+		"rs_edited":              cint(0x076678),                       // blue
+		"rs_disk_changes":        cint(0xcc241d),                       // red
+		"rs_not_exist":           cint(0xd65d0e),                       // orange
+		"rs_duplicate":           cint(0x83a598),                       // blueish
+		"rs_duplicate_highlight": cint(0xd79921),                       // yellow
+		"rs_annotations":         cint(0xb57614),                       // pumpkin
+		"rs_annotations_edited":  imageutil.Tint(cint(0xd35400), 0.45), // pumpkin (brighter)
+	}
+	
+	pal.Merge(p)
 	pal.Merge(userPalette())
 	node.Embed().SetThemePalette(pal)
 }
@@ -243,7 +255,7 @@ func gruvboxThemeColors(node widget.Node) {
 
 func rowSquarePalette() widget.Palette {
 	pal := widget.Palette{
-		"rs_active":              cint(0x282828),
+		"rs_active":              cint(0x0),
 		"rs_executing":           cint(0x0fad00),                       // dark green
 		"rs_edited":              cint(0x0000ff),                       // blue
 		"rs_disk_changes":        cint(0xff0000),                       // red

--- a/ui/theme.go
+++ b/ui/theme.go
@@ -192,9 +192,58 @@ func acmeThemeColors(node widget.Node) {
 
 //----------
 
+func gruvboxThemeColors(node widget.Node) {
+	pal := widget.Palette{
+		"text_cursor_fg":            cint(0xffffff),
+		"text_fg":                   cint(0xfbf1c7),
+		"text_bg":                   cint(0x282828),
+		"text_selection_fg":         nil,
+		"text_selection_bg":         cint(0x928374),
+		"text_colorize_string_fg":   cint(0xb8bb26),
+		"text_colorize_comments_fg": cint(0xa89984), 
+		"text_highlightword_fg":     nil,
+		"text_highlightword_bg":     cint(0x504945),
+		"text_wrapline_fg":          cint(0x0),
+		"text_wrapline_bg":          cint(0xd8d8c6),
+
+		"toolbar_text_bg":          cint(0x504945),
+		"toolbar_text_wrapline_bg": cint(0xc6d8d8),
+
+		"scrollbar_bg":        cint(0x1d2021),
+		"scrollhandle_normal": cint(0xa89984),
+		"scrollhandle_hover":  cint(0xadad6f),
+		"scrollhandle_select": cint(0x99994c),
+
+		"column_norows_rect":  cint(0x1d2021),
+		"columns_nocols_rect": cint(0x1d2021),
+		"colseparator_rect":   cint(0x282828),
+		"rowseparator_rect":   cint(0x282828),
+		"shadowsep_rect":      cint(0x282828),
+
+		"columnsquare": cint(0xb57614),
+		"rowsquare":    cint(0xb57614),
+
+		"mm_text_bg":          cint(0x1d2021),
+		"mm_button_hover_bg":  imageutil.Shade(cint(0xa89984), 0.10),
+		"mm_button_down_bg":   imageutil.Shade(cint(0xeaffff), 0.20),
+		"mm_button_sticky_bg": imageutil.Shade(cint(0xeaffff), 0.40),
+		"mm_border":           cint(0x282828),
+		"mm_content_pad":      cint(0xfbf1c7),
+		"mm_content_border":   cint(0x282828),
+
+		"contextfloatbox_border": cint(0x282828),
+	}
+
+	pal.Merge(rowSquarePalette())
+	pal.Merge(userPalette())
+	node.Embed().SetThemePalette(pal)
+}
+
+//----------
+
 func rowSquarePalette() widget.Palette {
 	pal := widget.Palette{
-		"rs_active":              cint(0x0),
+		"rs_active":              cint(0x282828),
 		"rs_executing":           cint(0x0fad00),                       // dark green
 		"rs_edited":              cint(0x0000ff),                       // blue
 		"rs_disk_changes":        cint(0xff0000),                       // red
@@ -211,6 +260,7 @@ func rowSquarePalette() widget.Palette {
 
 var ColorThemeCycler cycler = cycler{
 	entries: []cycleEntry{
+		{"gruvbox", gruvboxThemeColors},
 		{"light", lightThemeColors},
 		{"dark", darkThemeColors},
 		{"acme", acmeThemeColors},


### PR DESCRIPTION
Added [gruvbox](https://github.com/morhetz/gruvbox) inspired theme. I've been using this editor for a while and I really like it (been using it as my main editor for the past week), but the default dark theme didn't look very good in one of my monitors and the light ones hurt my eyes a bit after working for long periods of time. I use gruvbox on my vim config and I found it works quite well with editor.

![Screenshot from 2023-02-24 23-27-44](https://user-images.githubusercontent.com/47233777/221338387-fe94bf63-7c48-4b51-bf02-2c0de5304ff9.png)
