### PR TITLE
Clamping fontsize to a minimum to avoid a crash

### DIFF
--- a/ui/theme.go
+++ b/ui/theme.go
@@ -294,7 +294,13 @@ func ThemeFontFace2(name string, size float64) (*fontutil.FontFace, error) {
 		return nil, err
 	}
 	opt := TTFontOptions // copy
+
+	// if we have a font size specified
 	if size != 0 {
+		// clamp it to a safe minimum (font size of '1' can cause crashes)
+		if size < 3 {
+			size = 3
+		}
 		opt.Size = size
 	}
 	return f.FontFace(opt), nil


### PR DESCRIPTION
**Problem:**

When using font size adjustment in the header row, like `$font=regular,15`  a crash can be caused when deleting the trailing 5.  (This seemed most likely when applying the change to an open document.) Since the font change is immediate, the editor sees this as a change to a font of size 1 and that is apparently invalid.

**Solution**

Since the font size is invalid, I patched the system where the font is actually applied, so if there are other entry points they would presumably also be patched.

I also noticed that a font size of 0 seems to imply "don't change the font size" so that is maintained.