### PR TITLE
handle xproto.UnmapNotifyEvent

### DIFF
--- a/driver/xdriver/window.go
+++ b/driver/xdriver/window.go
@@ -266,6 +266,9 @@ func (win *Window) nextEvent2() any {
 			return err
 		}
 
+	case xproto.UnmapNotifyEvent: // window unmapped (hidden)
+		return nil
+
 	case xproto.KeyPressEvent:
 		return win.XInput.KeyPress(&t)
 	case xproto.KeyReleaseEvent:


### PR DESCRIPTION
`xproto.UnmapNotifyEvent` could be generated when using a window manager which map/unmap windows when switching workspaces.

no specific things should be done when it occurs, but not having the case leads to `log.Printf`.