### PR TITLE
lsp: send empty capabilities in "initialize" method.

### DIFF
--- a/core/lsproto/client.go
+++ b/core/lsproto/client.go
@@ -205,7 +205,7 @@ func (cli *Client) Initialize(ctx context.Context) error {
 }
 
 func (cli *Client) initializeParams() (json.RawMessage, error) {
-	opt := []string{}
+	opt := []string{"\"capabilities\":{}"}
 
 	//	rootUri, err := cli.rootUri()
 	//	if err != nil {


### PR DESCRIPTION
capabilities is mandatory, but could be empty, so just send it.

it unbreaks ocaml-lsp server usage.